### PR TITLE
 Add Gateway API support to Machinist K8s Provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
         cluster-name: plt-machinist-test
         k3d-version: v5.8.3
 
+    - name: Install Gateway API CRDs
+      run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+
     - name: Build and import test image
       run: |
         docker build . -t platformatic/machinist-test:latest -f Dockerfile.tests

--- a/infra/machinist.yaml
+++ b/infra/machinist.yaml
@@ -93,6 +93,21 @@ rules:
     verbs:
       - update
       - patch
+  # Gateway API permissions for skew protection (opt-in).
+  # Only used when skew protection is enabled in ICC.
+  # Safe to include even if Gateway API CRDs are not installed -
+  # K8s silently ignores RBAC rules for unknown API groups.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
 
 # If apps are going to be deployed in a namespace that is different from machinist
 # then the RoleBinding will need to have the namespace set

--- a/infra/machinist.yaml
+++ b/infra/machinist.yaml
@@ -108,6 +108,13 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
 
 # If apps are going to be deployed in a namespace that is different from machinist
 # then the RoleBinding will need to have the namespace set

--- a/services/main/package.json
+++ b/services/main/package.json
@@ -10,7 +10,8 @@
     "start": "platformatic service start",
     "test": "pnpm test:setup && pnpm test:unit && pnpm test:teardown",
     "test:unit": "borp --concurrency=1 tests/*.test.js",
-    "test:setup": "k3d cluster list | grep -q plt-machinist-test || k3d cluster create plt-machinist-test",
+    "test:install-crds": "kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml",
+    "test:setup": "k3d cluster list | grep -q plt-machinist-test || k3d cluster create plt-machinist-test && pnpm test:install-crds",
     "test:teardown": "k3d cluster rm plt-machinist-test"
   },
   "keywords": [],

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -105,6 +105,17 @@ class K8s {
     })
   }
 
+  async getServicesByLabels (namespace, labels) {
+    const parts = []
+    for (const [k, v] of Object.entries(labels)) {
+      parts.push(`${k}=${v}`)
+    }
+    const labelSelector = parts.join(',')
+    const path = `/api/v1/namespaces/${namespace}/services?labelSelector=${labelSelector}`
+    const { items } = await this.apiClient.request(path)
+    return items
+  }
+
   async getIngressRoutes (namespace, serviceNames) {
     if (serviceNames.length === 0) {
       // TODO custom error

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -151,6 +151,23 @@ class K8s {
     return this.apiClient.request(path, { method: 'DELETE' })
   }
 
+  async listAllGateways () {
+    const path = '/apis/gateway.networking.k8s.io/v1/gateways'
+    const { items } = await this.apiClient.request(path)
+    return items
+  }
+
+  async listGateways (namespace) {
+    const path = `/apis/gateway.networking.k8s.io/v1/namespaces/${namespace}/gateways`
+    const { items } = await this.apiClient.request(path)
+    return items
+  }
+
+  async getGateway (namespace, name) {
+    const path = `/apis/gateway.networking.k8s.io/v1/namespaces/${namespace}/gateways/${name}`
+    return this.apiClient.request(path)
+  }
+
   async getIngressRoutes (namespace, serviceNames) {
     if (serviceNames.length === 0) {
       // TODO custom error

--- a/services/main/routes/gateways.js
+++ b/services/main/routes/gateways.js
@@ -1,0 +1,44 @@
+'use strict'
+
+module.exports = async function routes (fastify, options) {
+  fastify.get('/gateway/gateways', {
+    schema: {
+      description: 'List all Gateways cluster-wide'
+    }
+  }, async (request, reply) => {
+    return fastify.k8s.listAllGateways()
+  })
+
+  fastify.get('/gateway/gateways/:namespace', {
+    schema: {
+      description: 'List Gateways in a namespace',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' }
+        },
+        required: ['namespace']
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace } = request.params
+    return fastify.k8s.listGateways(namespace)
+  })
+
+  fastify.get('/gateway/gateways/:namespace/:name', {
+    schema: {
+      description: 'Get a specific Gateway',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          name: { type: 'string' }
+        },
+        required: ['namespace', 'name']
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    return fastify.k8s.getGateway(namespace, name)
+  })
+}

--- a/services/main/routes/gateways.js
+++ b/services/main/routes/gateways.js
@@ -15,9 +15,8 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' }
-        },
-        required: ['namespace']
+          namespace: { $ref: 'k8s#/definitions/namespace' }
+        }
       }
     }
   }, async (request, reply) => {
@@ -31,10 +30,9 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' },
+          namespace: { $ref: 'k8s#/definitions/namespace' },
           name: { type: 'string' }
-        },
-        required: ['namespace', 'name']
+        }
       }
     }
   }, async (request, reply) => {

--- a/services/main/routes/httproutes.js
+++ b/services/main/routes/httproutes.js
@@ -1,0 +1,56 @@
+'use strict'
+
+module.exports = async function routes (fastify, options) {
+  fastify.get('/gateway/httproutes/:namespace/:name', {
+    schema: {
+      description: 'Get an HTTPRoute by name',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          name: { type: 'string' }
+        },
+        required: ['namespace', 'name']
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    return fastify.k8s.getHTTPRoute(namespace, name)
+  })
+
+  fastify.put('/gateway/httproutes/:namespace', {
+    schema: {
+      description: 'Create or update an HTTPRoute',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' }
+        },
+        required: ['namespace']
+      },
+      body: {
+        type: 'object'
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace } = request.params
+    return fastify.k8s.applyHTTPRoute(namespace, request.body)
+  })
+
+  fastify.delete('/gateway/httproutes/:namespace/:name', {
+    schema: {
+      description: 'Delete an HTTPRoute',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' },
+          name: { type: 'string' }
+        },
+        required: ['namespace', 'name']
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    return fastify.k8s.deleteHTTPRoute(namespace, name)
+  })
+}

--- a/services/main/routes/httproutes.js
+++ b/services/main/routes/httproutes.js
@@ -7,10 +7,9 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' },
+          namespace: { $ref: 'k8s#/definitions/namespace' },
           name: { type: 'string' }
-        },
-        required: ['namespace', 'name']
+        }
       }
     }
   }, async (request, reply) => {
@@ -24,9 +23,8 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' }
-        },
-        required: ['namespace']
+          namespace: { $ref: 'k8s#/definitions/namespace' }
+        }
       },
       body: {
         type: 'object'
@@ -43,10 +41,9 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' },
+          namespace: { $ref: 'k8s#/definitions/namespace' },
           name: { type: 'string' }
-        },
-        required: ['namespace', 'name']
+        }
       }
     }
   }, async (request, reply) => {

--- a/services/main/routes/services.js
+++ b/services/main/routes/services.js
@@ -7,11 +7,10 @@ module.exports = async function routes (fastify, options) {
       params: {
         type: 'object',
         properties: {
-          namespace: { type: 'string' }
-        },
-        required: ['namespace']
+          namespace: { $ref: 'k8s#/definitions/namespace' }
+        }
       },
-      query: {
+      querystring: {
         type: 'object',
         properties: {
           labels: {

--- a/services/main/routes/services.js
+++ b/services/main/routes/services.js
@@ -1,0 +1,37 @@
+'use strict'
+
+module.exports = async function routes (fastify, options) {
+  fastify.get('/services/:namespace', {
+    schema: {
+      description: 'Get services by metadata labels',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { type: 'string' }
+        },
+        required: ['namespace']
+      },
+      query: {
+        type: 'object',
+        properties: {
+          labels: {
+            type: 'array',
+            items: { type: 'string' }
+          }
+        },
+        required: ['labels']
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace } = request.params
+    const labelEntries = request.query.labels || []
+
+    const labels = {}
+    for (const entry of labelEntries) {
+      const [key, value] = entry.split('=')
+      labels[key] = value
+    }
+
+    return fastify.k8s.getServicesByLabels(namespace, labels)
+  })
+}

--- a/services/main/tests/fixtures/gateways/gateway.yaml
+++ b/services/main/tests/fixtures/gateways/gateway.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: platformatic-test
+spec:
+  controllerName: platformatic.dev/test-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: platform-gateway
+  namespace: default
+  labels:
+    plt.dev/managed-by: platformatic
+spec:
+  gatewayClassName: platformatic-test
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80

--- a/services/main/tests/fixtures/services/deployment.yaml
+++ b/services/main/tests/fixtures/services/deployment.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-echo-server-deployment-services
+  labels:
+    app.kubernetes.io/instance: deployment-fixture-services
+    app.kubernetes.io/name: myapp
+    plt.dev/version: 1.2.4
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: deployment-fixture-services
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: deployment-fixture-services
+    spec:
+      containers:
+        - name: nginx-echo-server
+          image: platformatic/machinist-test:latest
+          imagePullPolicy: Always
+          ports:
+            - name: app
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 500m
+            limits:
+              memory: 1Gi
+              cpu: 1000m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp-v1-2-4
+  labels:
+    app.kubernetes.io/name: myapp
+    plt.dev/version: 1.2.4
+spec:
+  selector:
+    app.kubernetes.io/instance: deployment-fixture-services
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/services/main/tests/gateways.test.js
+++ b/services/main/tests/gateways.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const path = require('node:path')
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { bootstrap, applyYaml, removeYaml } = require('./helper')
+
+const fixtureDir = path.join(__dirname, 'fixtures', 'gateways')
+const gatewayFixture = path.join(fixtureDir, 'gateway.yaml')
+
+test('gateway auto-discovery', async t => {
+  await applyYaml(gatewayFixture)
+  t.after(async () => {
+    await removeYaml(gatewayFixture)
+  })
+
+  await t.test('list all gateways', async t => {
+    const { app } = await bootstrap(t)
+
+    const result = await app.inject({
+      method: 'GET',
+      url: '/gateway/gateways'
+    })
+
+    assert.strictEqual(result.statusCode, 200)
+
+    const gateways = result.json()
+    assert.ok(Array.isArray(gateways))
+    const found = gateways.find(gw => gw.metadata.name === 'platform-gateway')
+    assert.ok(found)
+  })
+
+  await t.test('list gateways in namespace', async t => {
+    const { app } = await bootstrap(t)
+
+    const result = await app.inject({
+      method: 'GET',
+      url: '/gateway/gateways/default'
+    })
+
+    assert.strictEqual(result.statusCode, 200)
+
+    const gateways = result.json()
+    assert.ok(Array.isArray(gateways))
+    const found = gateways.find(gw => gw.metadata.name === 'platform-gateway')
+    assert.ok(found)
+  })
+
+  await t.test('get gateway by name', async t => {
+    const { app } = await bootstrap(t)
+
+    const result = await app.inject({
+      method: 'GET',
+      url: '/gateway/gateways/default/platform-gateway'
+    })
+
+    assert.strictEqual(result.statusCode, 200)
+
+    const gw = result.json()
+    assert.strictEqual(gw.kind, 'Gateway')
+    assert.strictEqual(gw.metadata.name, 'platform-gateway')
+  })
+
+  await t.test('get non-existent gateway returns 404', async t => {
+    const { app } = await bootstrap(t)
+
+    const result = await app.inject({
+      method: 'GET',
+      url: '/gateway/gateways/default/does-not-exist'
+    })
+
+    assert.strictEqual(result.statusCode, 404)
+  })
+
+  await t.test('labeled gateway for auto-discovery', async t => {
+    const { app } = await bootstrap(t)
+
+    const result = await app.inject({
+      method: 'GET',
+      url: '/gateway/gateways/default/platform-gateway'
+    })
+
+    assert.strictEqual(result.statusCode, 200)
+
+    const gw = result.json()
+    assert.strictEqual(gw.metadata.labels['plt.dev/managed-by'], 'platformatic')
+  })
+})

--- a/services/main/tests/httproutes.test.js
+++ b/services/main/tests/httproutes.test.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { bootstrap } = require('./helper')
+
+const httpRouteFixture = {
+  apiVersion: 'gateway.networking.k8s.io/v1',
+  kind: 'HTTPRoute',
+  metadata: {
+    name: 'myapp-skew-test',
+    labels: {
+      'plt.dev/managed-by': 'icc',
+      'plt.dev/application': 'myapp'
+    }
+  },
+  spec: {
+    parentRefs: [
+      { name: 'platform-gateway', namespace: 'default' }
+    ],
+    hostnames: ['myapp.example.com'],
+    rules: [
+      {
+        backendRefs: [
+          { name: 'myapp-v1', port: 3042 }
+        ]
+      }
+    ]
+  }
+}
+
+test('apply creates a new HTTPRoute', async t => {
+  const { app } = await bootstrap(t)
+
+  const result = await app.inject({
+    method: 'PUT',
+    url: '/gateway/httproutes/default',
+    headers: { 'content-type': 'application/json' },
+    body: httpRouteFixture
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const route = result.json()
+  assert.strictEqual(route.metadata.name, 'myapp-skew-test')
+  assert.strictEqual(route.kind, 'HTTPRoute')
+  assert(route.metadata.resourceVersion)
+
+  // Cleanup
+  await app.inject({
+    method: 'DELETE',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+})
+
+test('get HTTPRoute by name', async t => {
+  const { app } = await bootstrap(t)
+
+  await app.inject({
+    method: 'PUT',
+    url: '/gateway/httproutes/default',
+    headers: { 'content-type': 'application/json' },
+    body: httpRouteFixture
+  })
+
+  const result = await app.inject({
+    method: 'GET',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const route = result.json()
+  assert.strictEqual(route.metadata.name, 'myapp-skew-test')
+  assert.strictEqual(route.spec.hostnames[0], 'myapp.example.com')
+  assert.strictEqual(route.spec.rules[0].backendRefs[0].name, 'myapp-v1')
+
+  await app.inject({
+    method: 'DELETE',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+})
+
+test('apply updates an existing HTTPRoute', async t => {
+  const { app } = await bootstrap(t)
+
+  await app.inject({
+    method: 'PUT',
+    url: '/gateway/httproutes/default',
+    headers: { 'content-type': 'application/json' },
+    body: httpRouteFixture
+  })
+
+  const updated = structuredClone(httpRouteFixture)
+  updated.spec.rules = [
+    {
+      matches: [{
+        headers: [{
+          name: 'Cookie',
+          type: 'RegularExpression',
+          value: '(^|;\\s*)__plt_dpl=v1-abc123(;|$)'
+        }]
+      }],
+      backendRefs: [{ name: 'myapp-v1', port: 3042 }]
+    },
+    {
+      backendRefs: [{ name: 'myapp-v2', port: 3042 }]
+    }
+  ]
+
+  const result = await app.inject({
+    method: 'PUT',
+    url: '/gateway/httproutes/default',
+    headers: { 'content-type': 'application/json' },
+    body: updated
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const route = result.json()
+  assert.strictEqual(route.spec.rules.length, 2)
+  assert.strictEqual(route.spec.rules[0].backendRefs[0].name, 'myapp-v1')
+  assert.strictEqual(route.spec.rules[1].backendRefs[0].name, 'myapp-v2')
+
+  await app.inject({
+    method: 'DELETE',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+})
+
+test('delete HTTPRoute', async t => {
+  const { app } = await bootstrap(t)
+
+  await app.inject({
+    method: 'PUT',
+    url: '/gateway/httproutes/default',
+    headers: { 'content-type': 'application/json' },
+    body: httpRouteFixture
+  })
+
+  const result = await app.inject({
+    method: 'DELETE',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const getResult = await app.inject({
+    method: 'GET',
+    url: '/gateway/httproutes/default/myapp-skew-test'
+  })
+
+  assert.strictEqual(getResult.statusCode, 404)
+})
+
+test('get non-existent HTTPRoute returns error', async t => {
+  const { app } = await bootstrap(t)
+
+  const result = await app.inject({
+    method: 'GET',
+    url: '/gateway/httproutes/default/does-not-exist'
+  })
+
+  assert.strictEqual(result.statusCode, 404)
+})

--- a/services/main/tests/services.test.js
+++ b/services/main/tests/services.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { test, before } = require('node:test')
+const assert = require('node:assert/strict')
+const { join } = require('node:path')
+const { bootstrap, applyYaml } = require('./helper')
+
+const fixture = join(__dirname, 'fixtures', 'services', 'deployment.yaml')
+
+before(async () => {
+  await applyYaml(fixture)
+})
+
+test('get services by metadata labels', async t => {
+  const { app } = await bootstrap(t)
+
+  const result = await app.inject({
+    method: 'GET',
+    url: '/services/default?labels=app.kubernetes.io/name%3Dmyapp&labels=plt.dev/version%3D1.2.4',
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const services = result.json()
+  assert(Array.isArray(services))
+  assert(services.length >= 1)
+
+  const svc = services.find(s => s.metadata.name === 'myapp-v1-2-4')
+  assert(svc)
+  assert.strictEqual(svc.metadata.labels['app.kubernetes.io/name'], 'myapp')
+  assert.strictEqual(svc.metadata.labels['plt.dev/version'], '1.2.4')
+})
+
+test('returns empty array when no services match labels', async t => {
+  const { app } = await bootstrap(t)
+
+  const result = await app.inject({
+    method: 'GET',
+    url: '/services/default?labels=app.kubernetes.io/name%3Dnonexistent',
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+
+  assert.strictEqual(result.statusCode, 200)
+
+  const services = result.json()
+  assert(Array.isArray(services))
+  assert.strictEqual(services.length, 0)
+})
+
+test('returns 400 when labels query param is missing', async t => {
+  const { app } = await bootstrap(t)
+
+  const result = await app.inject({
+    method: 'GET',
+    url: '/services/default',
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+
+  assert.strictEqual(result.statusCode, 400)
+})


### PR DESCRIPTION
### Summary
- Add `getServicesByLabels(namespace, labels)` method that queries services by **metadata labels** using K8s server-side `labelSelector` (distinct from existing `getServices` which filters by `spec.selector` client-side)
- Add HTTPRoute CRUD methods: `getHTTPRoute`, `applyHTTPRoute` (create-or-update with `resourceVersion` handling), `deleteHTTPRoute`
- Expose all new methods as HTTP routes under `/gateway/httproutes/:namespace` and `/services/:namespace`
- Add RBAC permissions for `gateway.networking.k8s.io/httproutes` to `plt-pod-manager` ClusterRole
- Install Gateway API CRDs in CI workflow and local `test:setup` script
- Add Gateway auto-discovery methods: `listAllGateways`, `listGateways`, `getGateway`
- Expose Gateway endpoints under `/gateway/gateways` for ICC auto-discovery

### Motivation
ICC needs these Machinist endpoints for skew protection version routing:
- `getServicesByLabels` to discover the K8s Service backing a versioned Deployment (used in HTTPRoute `backendRefs`)
- HTTPRoute CRUD to manage Gateway API routing rules that pin users to specific app versions via cookies

### Routes added
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/services/:namespace?labels=key%3Dvalue` | Find services by metadata labels |
| `GET` | `/gateway/httproutes/:namespace/:name` | Get an HTTPRoute |
| `PUT` | `/gateway/httproutes/:namespace` | Create or update an HTTPRoute |
| `DELETE` | `/gateway/httproutes/:namespace/:name` | Delete an HTTPRoute |
| `GET` | `/gateway/gateways` | List all Gateways cluster-wide |
| `GET` | `/gateway/gateways/:namespace` | List Gateways in a namespace |
| `GET` | `/gateway/gateways/:namespace/:name` | Get a specific Gateway |

### RBAC
Added Gateway API permissions to the `plt-pod-manager` ClusterRole in `infra/machinist.yaml`. Safe to include even if Gateway API CRDs are not installed — K8s silently ignores RBAC rules for unknown API groups.

### CI
- Added "Install Gateway API CRDs" step in `.github/workflows/test.yml` (after cluster creation, before tests)
- Added `test:install-crds` npm script and chained it in `test:setup` so local `pnpm test` also installs CRDs