### PR TITLE
Deployment and Service deletion API

### DIFF
--- a/infra/machinist.yaml
+++ b/infra/machinist.yaml
@@ -93,6 +93,15 @@ rules:
     verbs:
       - update
       - patch
+  # Skew protection auto-cleanup: delete expired Deployments and Services
+  - apiGroups:
+      - ""
+      - apps
+    resources:
+      - deployments
+      - services
+    verbs:
+      - delete
   # Gateway API permissions for skew protection (opt-in).
   # Only used when skew protection is enabled in ICC.
   # Safe to include even if Gateway API CRDs are not installed -

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -151,6 +151,16 @@ class K8s {
     return this.apiClient.request(path, { method: 'DELETE' })
   }
 
+  async deleteDeployment (namespace, name) {
+    const path = `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`
+    return this.apiClient.request(path, { method: 'DELETE' })
+  }
+
+  async deleteService (namespace, name) {
+    const path = `/api/v1/namespaces/${namespace}/services/${name}`
+    return this.apiClient.request(path, { method: 'DELETE' })
+  }
+
   async listAllGateways () {
     const path = '/apis/gateway.networking.k8s.io/v1/gateways'
     const { items } = await this.apiClient.request(path)

--- a/services/main/routes/controller.js
+++ b/services/main/routes/controller.js
@@ -148,6 +148,22 @@ module.exports = async function routes (fastify, options) {
     }
   })
 
+  fastify.delete('/deployments/:namespace/:name', {
+    schema: {
+      description: 'Delete a Deployment',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'k8s#/definitions/namespace' },
+          name: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    return fastify.k8s.deleteDeployment(namespace, name)
+  })
+
   fastify.post('/controllers/:namespace/:controllerId', {
     schema: {
       description: 'Update number of replicas for a controller',

--- a/services/main/routes/services.js
+++ b/services/main/routes/services.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = async function routes (fastify, options) {
+module.exports = async function routes (fastify) {
   fastify.get('/services/:namespace', {
     schema: {
       description: 'Get services by metadata labels',
@@ -32,5 +32,21 @@ module.exports = async function routes (fastify, options) {
     }
 
     return fastify.k8s.getServicesByLabels(namespace, labels)
+  })
+
+  fastify.delete('/services/:namespace/:name', {
+    schema: {
+      description: 'Delete a Service',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'k8s#/definitions/namespace' },
+          name: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    return fastify.k8s.deleteService(namespace, name)
   })
 }


### PR DESCRIPTION
Adds `DELETE` endpoints for Deployments and Services, used by ICC's skew protection cleanup flow to remove expired versioned resources.

### What changed

#### K8s provider (`plugins/providers/k8s.js`)

- `deleteDeployment(namespace, name)` — calls `DELETE /apis/apps/v1/namespaces/{ns}/deployments/{name}`
- `deleteService(namespace, name)` — calls `DELETE /api/v1/namespaces/{ns}/services/{name}`

#### Routes

- `DELETE /deployments/:namespace/:name` — added to `routes/controller.js`
- `DELETE /services/:namespace/:name` — added to `routes/services.js`

#### RBAC (`infra/machinist.yaml`)

Added `delete` verb for `deployments` and `services` resources in the ClusterRole, needed for the auto-cleanup of expired versions.