### PR TITLE
Apply deployment services

### DIFF
--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -213,6 +213,66 @@ class K8s {
     return this.apiClient.request(path, { method: 'DELETE' })
   }
 
+  // ── Workload creation (K8s only) ──
+
+  // Idempotent create-or-update of a Deployment, mirroring applyHTTPRoute: GET
+  // the resource, swallow only 404, PUT with the existing resourceVersion when
+  // it exists, else POST.
+  async applyDeployment (namespace, deployment) {
+    const name = deployment.metadata.name
+    const basePath = `/apis/apps/v1/namespaces/${namespace}/deployments`
+
+    let existing
+    try {
+      existing = await this.apiClient.request(`${basePath}/${name}`)
+    } catch (err) {
+      if (err.statusCode !== 404) throw err
+    }
+
+    if (existing) {
+      deployment.metadata.resourceVersion = existing.metadata.resourceVersion
+      return this.apiClient.request(`${basePath}/${name}`, {
+        method: 'PUT',
+        body: JSON.stringify(deployment)
+      })
+    }
+
+    return this.apiClient.request(basePath, {
+      method: 'POST',
+      body: JSON.stringify(deployment)
+    })
+  }
+
+  // Idempotent create-or-update of a Service. spec.clusterIP is immutable — a PUT
+  // that changes it is rejected — so echo the existing clusterIP (and
+  // resourceVersion) back onto the update body.
+  async applyService (namespace, service) {
+    const name = service.metadata.name
+    const basePath = `/api/v1/namespaces/${namespace}/services`
+
+    let existing
+    try {
+      existing = await this.apiClient.request(`${basePath}/${name}`)
+    } catch (err) {
+      if (err.statusCode !== 404) throw err
+    }
+
+    if (existing) {
+      service.metadata.resourceVersion = existing.metadata.resourceVersion
+      service.spec = service.spec || {}
+      service.spec.clusterIP = existing.spec.clusterIP
+      return this.apiClient.request(`${basePath}/${name}`, {
+        method: 'PUT',
+        body: JSON.stringify(service)
+      })
+    }
+
+    return this.apiClient.request(basePath, {
+      method: 'POST',
+      body: JSON.stringify(service)
+    })
+  }
+
   // ── Private helpers ──
 
   #formatMachine (pod) {

--- a/services/main/routes/controllers.js
+++ b/services/main/routes/controllers.js
@@ -119,6 +119,24 @@ module.exports = async function routes (fastify) {
     return fastify.provider.updateControllerReplicas(namespace, name, replicas, providerMetadata)
   })
 
+  fastify.put('/controllers/:namespace', {
+    schema: {
+      description: 'Create or update a Deployment (idempotent)',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'machinist#/definitions/namespace' }
+        }
+      },
+      body: {
+        type: 'object'
+      }
+    }
+  }, async (request) => {
+    const { namespace } = request.params
+    return fastify.provider.applyDeployment(namespace, request.body)
+  })
+
   fastify.delete('/controllers/:namespace/:name', {
     schema: {
       params: {

--- a/services/main/routes/services.js
+++ b/services/main/routes/services.js
@@ -60,6 +60,24 @@ module.exports = async function routes (fastify) {
     return fastify.provider.getServicesByLabels(namespace, labels)
   })
 
+  fastify.put('/services/:namespace', {
+    schema: {
+      description: 'Create or update a Service (idempotent)',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'machinist#/definitions/namespace' }
+        }
+      },
+      body: {
+        type: 'object'
+      }
+    }
+  }, async (request) => {
+    const { namespace } = request.params
+    return fastify.provider.applyService(namespace, request.body)
+  })
+
   fastify.delete('/services/:namespace/:name', {
     schema: {
       params: {

--- a/services/main/tests/k8s-apply-workload.test.js
+++ b/services/main/tests/k8s-apply-workload.test.js
@@ -1,0 +1,106 @@
+'use strict'
+
+// Unit tests for the K8s provider's applyDeployment/applyService idempotency.
+// These don't need a k3d cluster — a fake apiClient records the requests.
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { K8s } = require('../plugins/providers/k8s')
+
+function buildProvider () {
+  return new K8s({
+    config: {
+      PLT_K8S_REST_API_URL: 'http://k8s.local',
+      PLT_K8S_ALLOW_SELFSIGNED_CERT: true
+    },
+    log: { debug () {}, info () {}, warn () {}, error () {} },
+    caContent: '',
+    token: 'test',
+    authType: 'token',
+    clientCreds: {}
+  })
+}
+
+function notFound () {
+  const err = new Error('not found')
+  err.statusCode = 404
+  return err
+}
+
+// Fake apiClient: records requests, answers the probe GET from `existing`.
+function fakeClient ({ existing = null } = {}) {
+  const calls = []
+  return {
+    calls,
+    request: async (path, overrides = {}) => {
+      const method = overrides.method || 'GET'
+      calls.push({ path, method, body: overrides.body ? JSON.parse(overrides.body) : undefined })
+      if (method === 'GET') {
+        if (existing) return existing
+        throw notFound()
+      }
+      return { ok: true }
+    }
+  }
+}
+
+test('applyDeployment POSTs a new Deployment when none exists', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({ existing: null })
+  k8s.apiClient = client
+
+  await k8s.applyDeployment('platformatic', { metadata: { name: 'my-app-v1' }, spec: {} })
+
+  assert.strictEqual(client.calls.length, 2)
+  assert.strictEqual(client.calls[0].method, 'GET')
+  assert.strictEqual(client.calls[0].path, '/apis/apps/v1/namespaces/platformatic/deployments/my-app-v1')
+  assert.strictEqual(client.calls[1].method, 'POST')
+  assert.strictEqual(client.calls[1].path, '/apis/apps/v1/namespaces/platformatic/deployments')
+  assert.strictEqual(client.calls[1].body.metadata.name, 'my-app-v1')
+})
+
+test('applyDeployment PUTs with the existing resourceVersion on update (idempotent)', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({ existing: { metadata: { name: 'my-app-v1', resourceVersion: 'rv-42' } } })
+  k8s.apiClient = client
+
+  await k8s.applyDeployment('platformatic', { metadata: { name: 'my-app-v1' }, spec: {} })
+
+  assert.strictEqual(client.calls[1].method, 'PUT')
+  assert.strictEqual(client.calls[1].path, '/apis/apps/v1/namespaces/platformatic/deployments/my-app-v1')
+  assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-42')
+})
+
+test('applyService POSTs a new Service when none exists', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({ existing: null })
+  k8s.apiClient = client
+
+  await k8s.applyService('platformatic', { metadata: { name: 'my-app-v1-svc' }, spec: { type: 'ClusterIP' } })
+
+  assert.strictEqual(client.calls[1].method, 'POST')
+  assert.strictEqual(client.calls[1].path, '/api/v1/namespaces/platformatic/services')
+})
+
+test('applyService echoes the immutable clusterIP + resourceVersion on update', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({
+    existing: { metadata: { name: 'my-app-v1-svc', resourceVersion: 'rv-7' }, spec: { clusterIP: '10.43.0.9' } }
+  })
+  k8s.apiClient = client
+
+  await k8s.applyService('platformatic', { metadata: { name: 'my-app-v1-svc' }, spec: { type: 'ClusterIP' } })
+
+  assert.strictEqual(client.calls[1].method, 'PUT')
+  assert.strictEqual(client.calls[1].body.spec.clusterIP, '10.43.0.9')
+  assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-7')
+})
+
+test('applyDeployment rethrows non-404 probe errors', async () => {
+  const k8s = buildProvider()
+  const boom = new Error('boom')
+  boom.statusCode = 500
+  k8s.apiClient = { request: async () => { throw boom } }
+
+  await assert.rejects(() => k8s.applyDeployment('platformatic', { metadata: { name: 'x' } }), /boom/)
+})


### PR DESCRIPTION
Adds idempotent `applyDeployment` and `applyService` primitives to the K8s provider, plus `PUT /controllers/:namespace` and `PUT /services/:namespace` routes, so ICC can create versioned workloads for skew-protection **manage** mode.

## Why

Part of PRD-1862 (deploy creation flow, manage mode). Machinist could already *route* (HTTPRoute) and *tear down* (scale/delete) workloads, but not **create** them. Manage-mode deploys need ICC to create the Deployment + Service via machinist; advise-mode returns the same manifests as a plan for an external actor.

## Backward compatibility

The new routes are dormant unless called, so any current ICC (with no deploy modes) works unchanged