### PR TITLE
watch gateway config in advise mode

### DIFF
--- a/services/main/plugins/providers/ecs.js
+++ b/services/main/plugins/providers/ecs.js
@@ -236,6 +236,10 @@ class Ecs {
     throw new errors.NotImplementedByProvider('Skew protection (applyHTTPRoute)', 'ecs')
   }
 
+  async getHTTPRoute () {
+    throw new errors.NotImplementedByProvider('Skew protection (getHTTPRoute)', 'ecs')
+  }
+
   async deleteHTTPRoute () {
     throw new errors.NotImplementedByProvider('Skew protection (deleteHTTPRoute)', 'ecs')
   }

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -208,6 +208,16 @@ class K8s {
     })
   }
 
+  async getHTTPRoute (namespace, name) {
+    const path = `/apis/gateway.networking.k8s.io/v1/namespaces/${namespace}/httproutes/${name}`
+    try {
+      return await this.apiClient.request(path)
+    } catch (err) {
+      if (err.statusCode === 404) return null
+      throw err
+    }
+  }
+
   async deleteHTTPRoute (namespace, name) {
     const path = `/apis/gateway.networking.k8s.io/v1/namespaces/${namespace}/httproutes/${name}`
     return this.apiClient.request(path, { method: 'DELETE' })

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { readFile } = require('node:fs/promises')
-const querystring = require('fast-querystring')
 const fp = require('fastify-plugin')
 const pluralize = require('pluralize')
 const K8sClient = require('../../lib/k8s-client')
@@ -55,7 +54,10 @@ class K8s {
   }
 
   async getMachines (namespace, labels = {}) {
-    const labelSelector = querystring.stringify(labels)
+    // k8s labelSelector is comma-separated. querystring.stringify joins with `&`,
+    // which splits every label after the first off into ignored query params, so
+    // only the first label actually filters. Join with `,` like getServicesByLabels.
+    const labelSelector = Object.entries(labels).map(([k, v]) => `${k}=${v}`).join(',')
     const endpoint = `/api/v1/namespaces/${namespace}/pods?labelSelector=${labelSelector}`
     const { items } = await this.apiClient.request(endpoint)
 

--- a/services/main/routes/httproutes.js
+++ b/services/main/routes/httproutes.js
@@ -22,6 +22,26 @@ module.exports = async function routes (fastify) {
     return fastify.provider.applyHTTPRoute(namespace, request.body)
   })
 
+  fastify.get('/gateway/httproutes/:namespace/:name', {
+    schema: {
+      description: 'Get an HTTPRoute',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'machinist#/definitions/namespace' },
+          name: { type: 'string' }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const { namespace, name } = request.params
+    const route = await fastify.provider.getHTTPRoute(namespace, name)
+    if (!route) {
+      return reply.code(404).send({ message: `HTTPRoute ${namespace}/${name} not found` })
+    }
+    return route
+  })
+
   fastify.delete('/gateway/httproutes/:namespace/:name', {
     schema: {
       description: 'Delete an HTTPRoute',


### PR DESCRIPTION
## What

Two changes that let ICC *observe* the cluster in advise mode, where ICC actuates nothing and only reflects the state the customer's CI applies:

1. Adds a read path for HTTPRoutes (`GET`), which machinist was missing (it had `PUT`/`DELETE` only).
2. Fixes `getMachines` label filtering so a pod query narrows by every label, not just the first.

## Why

In advise mode ICC confirms lifecycle transitions by observation:
- `pending-apply -> active` once it sees the new pods registered AND the live HTTPRoute serving that version as default with the gateway `Accepted` condition.
- `draining -> expired` once it sees the customer removed the workload (no pods left for that version).

Both need machinist reads. Two gaps blocked them:

- **No HTTPRoute read.** `getHTTPRoute` 404'd (`Route GET:/k8s/gateway/httproutes/<ns>/<name> not found`), so the confirm's `routeReady` never became true and versions were stuck in `pending-apply`.
- **`getMachines` dropped all but the first label.** It built the k8s `labelSelector` with `querystring.stringify(labels)`, which joins with `&`; a labelSelector must be comma-separated, so `?labelSelector=app.kubernetes.io/name=leads-demo&plt.dev/version=v2` split the version off as an ignored query param. The query returned *every* pod of the app, not the one version. This is a silent over-match: it happened to be harmless for the only prior caller (which checks pods are *present*, where a superset still reads as present), but the new teardown check asks the opposite -- are this version's pods *gone* -- and a superset (another version's pods) made a torn-down version look alive forever. `getServicesByLabels` already joined with `,` correctly; `getMachines` had diverged.


