### PR TITLE
Export image digest 

### DIFF
--- a/services/main/plugins/providers/ecs.js
+++ b/services/main/plugins/providers/ecs.js
@@ -262,6 +262,14 @@ class Ecs {
     // Image + resources from first container
     if (task.containers?.length > 0) {
       output.image = task.containers[0].image
+      // The content-addressed digest ECS resolved for the running image
+      // (DescribeTasks -> containers[].imageDigest), the analog of the k8s
+      // provider's status.imageID. Unlike the task-def image tag it changes if
+      // the image content changes, so consumers can version by content. ECS
+      // returns a bare `sha256:...`.
+      if (task.containers[0].imageDigest) {
+        output.imageDigest = task.containers[0].imageDigest
+      }
     }
 
     // Task-level resources (ECS has no requests/limits distinction)

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -311,6 +311,15 @@ class K8s {
       output.resources = pod.spec.containers[0].resources
     }
 
+    // The content-addressed digest Kubernetes resolved for the running image.
+    // Unlike spec.image (a possibly-mutable tag like `:latest`), this changes
+    // iff the image content changes, so consumers can version by content. Format
+    // is `<repo>@sha256:...`, sometimes prefixed with `docker-pullable://`.
+    const imageID = pod.status?.containerStatuses?.[0]?.imageID
+    if (imageID) {
+      output.imageDigest = imageID.replace(/^docker-pullable:\/\//, '')
+    }
+
     return output
   }
 

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -312,9 +312,6 @@ class K8s {
     }
 
     // The content-addressed digest Kubernetes resolved for the running image.
-    // Unlike spec.image (a possibly-mutable tag like `:latest`), this changes
-    // iff the image content changes, so consumers can version by content. Format
-    // is `<repo>@sha256:...`, sometimes prefixed with `docker-pullable://`.
     const imageID = pod.status?.containerStatuses?.[0]?.imageID
     if (imageID) {
       output.imageDigest = imageID.replace(/^docker-pullable:\/\//, '')

--- a/services/main/plugins/shared-schemas.js
+++ b/services/main/plugins/shared-schemas.js
@@ -20,6 +20,7 @@ module.exports = fp(function (fastify, opts, done) {
       status: { type: 'string' },
       startTime: { type: 'string', format: 'date-time' },
       image: { type: 'string' },
+      imageDigest: { type: 'string' },
       labels: {
         type: 'object',
         patternProperties: {

--- a/services/main/tests/ecs-provider.test.js
+++ b/services/main/tests/ecs-provider.test.js
@@ -2,6 +2,8 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
+const ecsSdk = require('@aws-sdk/client-ecs')
+const { Ecs } = require('../plugins/providers/ecs')
 
 function mockTask (overrides = {}) {
   return {
@@ -112,6 +114,37 @@ test('Ecs#formatMachine extracts correct fields from ECS task', async () => {
   assert.strictEqual(task.cpu, '256')
   assert.strictEqual(task.memory, '512')
   assert.strictEqual(task.tags[0].key, 'app.kubernetes.io/name')
+})
+
+// Drive the real Ecs#formatMachine via getMachine with the ECS client's send()
+// stubbed, so we exercise the actual field mapping (the mock provider above
+// bypasses it).
+async function getMachineWithTask (task) {
+  const originalSend = ecsSdk.ECSClient.prototype.send
+  ecsSdk.ECSClient.prototype.send = async () => ({ tasks: [task], failures: [] })
+  try {
+    const ecs = new Ecs({
+      config: { PLT_ECS_REGION: 'us-east-1', PLT_ECS_CLUSTER: 'my-cluster' },
+      log: { debug () {} }
+    })
+    return await ecs.getMachine('my-cluster', task.taskArn)
+  } finally {
+    ecsSdk.ECSClient.prototype.send = originalSend
+  }
+}
+
+test('Ecs#formatMachine surfaces the container imageDigest', async () => {
+  const machine = await getMachineWithTask(mockTask({
+    containers: [{ name: 'web', image: 'myapp:latest', imageDigest: 'sha256:b0162380' }]
+  }))
+  assert.strictEqual(machine.image, 'myapp:latest')
+  assert.strictEqual(machine.imageDigest, 'sha256:b0162380')
+})
+
+test('Ecs#formatMachine omits imageDigest when the task container has none', async () => {
+  const machine = await getMachineWithTask(mockTask()) // default container carries no imageDigest
+  assert.strictEqual(machine.image, 'myapp:latest')
+  assert.strictEqual(machine.imageDigest, undefined)
 })
 
 test('task.group parsing extracts service name', async () => {
@@ -341,8 +374,6 @@ test('DELETE /ecs/services/:namespace/:name is a no-op for ECS', async (t) => {
 })
 
 // ── Skew protection: ECS provider rejects with a clean 501 ──
-
-const { Ecs } = require('../plugins/providers/ecs')
 
 function buildEcs () {
   return new Ecs({


### PR DESCRIPTION
Surface the running image's content digest on the Machine object so consumers can version by content instead of by a possibly-mutable image tag.
Supoprts both K8S and ECS providers. 