### PR TITLE
expose machine ready status (k8s + ecs)

### DIFF
--- a/services/main/plugins/providers/ecs.js
+++ b/services/main/plugins/providers/ecs.js
@@ -264,9 +264,7 @@ class Ecs {
       output.image = task.containers[0].image
       // The content-addressed digest ECS resolved for the running image
       // (DescribeTasks -> containers[].imageDigest), the analog of the k8s
-      // provider's status.imageID. Unlike the task-def image tag it changes if
-      // the image content changes, so consumers can version by content. ECS
-      // returns a bare `sha256:...`.
+      // provider's status.imageID.
       if (task.containers[0].imageDigest) {
         output.imageDigest = task.containers[0].imageDigest
       }
@@ -284,6 +282,10 @@ class Ecs {
       }
       output.resources = resources
     }
+
+    // ECS analog of the k8s pod Ready condition: RUNNING and not failing its health
+    // check (healthStatus is UNKNOWN when no check is defined -> RUNNING is enough).
+    output.ready = task.lastStatus === 'RUNNING' && task.healthStatus !== 'UNHEALTHY'
 
     return output
   }

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -317,6 +317,11 @@ class K8s {
       output.imageDigest = imageID.replace(/^docker-pullable:\/\//, '')
     }
 
+    // The kubelet's Ready verdict -- what gates the pod's inclusion in the Service
+    // endpoints, i.e. whether the gateway can route to it.
+    const readyCond = pod.status?.conditions?.find(c => c.type === 'Ready')
+    output.ready = readyCond?.status === 'True'
+
     return output
   }
 

--- a/services/main/plugins/shared-schemas.js
+++ b/services/main/plugins/shared-schemas.js
@@ -21,6 +21,7 @@ module.exports = fp(function (fastify, opts, done) {
       startTime: { type: 'string', format: 'date-time' },
       image: { type: 'string' },
       imageDigest: { type: 'string' },
+      ready: { type: 'boolean' },
       labels: {
         type: 'object',
         patternProperties: {


### PR DESCRIPTION
Add a `ready` boolean to the Machine object: on Kubernetes from the pod's `Ready` condition, on ECS from the task being RUNNING and not UNHEALTHY -- i.e. whether the workload can serve traffic (on k8s the Ready condition is also what gates the pod's inclusion in the Service endpoints). Added to the shared machine schema. ICC uses it to hold a version's route cutover until its pods are Ready (paired icc-3 PR). ECS provider tests cover the field.
