### PR TITLE
Apply image pull secrets for the deployer API

### DIFF
--- a/services/main/plugins/providers/ecs.js
+++ b/services/main/plugins/providers/ecs.js
@@ -244,6 +244,13 @@ class Ecs {
     throw new errors.NotImplementedByProvider('Skew protection (deleteHTTPRoute)', 'ecs')
   }
 
+  // K8s image-pull secrets have no ECS analog: ECS pulls private images via a
+  // task-definition repositoryCredentials (a Secrets Manager ARN), set when the
+  // task is registered, not as a standalone resource.
+  async applySecret () {
+    throw new errors.NotImplementedByProvider('Image pull secret (applySecret)', 'ecs')
+  }
+
   // ── Private helpers ──
 
   #formatMachine (task) {

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -285,30 +285,18 @@ class K8s {
     })
   }
 
-  // Idempotent create-or-update of a Secret, mirroring applyDeployment. Used for
-  // image-pull secrets so a pod can pull a private image; the caller (ICC) holds
-  // the credentials for the length of this request only.
+  // Idempotent create-or-update of an image-pull Secret via server-side apply: a
+  // single PATCH, no read-before-write. This deliberately avoids GET on secrets
+  // (which would let the SA read every secret's contents in the namespace); SSA
+  // needs only create + patch. fieldManager marks ICC as the owner and force
+  // takes ownership of any conflicting fields. The manifest carries apiVersion +
+  // kind, as SSA requires.
   async applySecret (namespace, secret) {
     const name = secret.metadata.name
-    const basePath = `/api/v1/namespaces/${namespace}/secrets`
-
-    let existing
-    try {
-      existing = await this.apiClient.request(`${basePath}/${name}`)
-    } catch (err) {
-      if (err.statusCode !== 404) throw err
-    }
-
-    if (existing) {
-      secret.metadata.resourceVersion = existing.metadata.resourceVersion
-      return this.apiClient.request(`${basePath}/${name}`, {
-        method: 'PUT',
-        body: JSON.stringify(secret)
-      })
-    }
-
-    return this.apiClient.request(basePath, {
-      method: 'POST',
+    const path = `/api/v1/namespaces/${namespace}/secrets/${name}?fieldManager=icc&force=true`
+    return this.apiClient.request(path, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/apply-patch+yaml' },
       body: JSON.stringify(secret)
     })
   }

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -285,6 +285,34 @@ class K8s {
     })
   }
 
+  // Idempotent create-or-update of a Secret, mirroring applyDeployment. Used for
+  // image-pull secrets so a pod can pull a private image; the caller (ICC) holds
+  // the credentials for the length of this request only.
+  async applySecret (namespace, secret) {
+    const name = secret.metadata.name
+    const basePath = `/api/v1/namespaces/${namespace}/secrets`
+
+    let existing
+    try {
+      existing = await this.apiClient.request(`${basePath}/${name}`)
+    } catch (err) {
+      if (err.statusCode !== 404) throw err
+    }
+
+    if (existing) {
+      secret.metadata.resourceVersion = existing.metadata.resourceVersion
+      return this.apiClient.request(`${basePath}/${name}`, {
+        method: 'PUT',
+        body: JSON.stringify(secret)
+      })
+    }
+
+    return this.apiClient.request(basePath, {
+      method: 'POST',
+      body: JSON.stringify(secret)
+    })
+  }
+
   // ── Private helpers ──
 
   #formatMachine (pod) {

--- a/services/main/routes/secrets.js
+++ b/services/main/routes/secrets.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = async function routes (fastify) {
+  fastify.put('/secrets/:namespace', {
+    schema: {
+      description: 'Create or update a Secret (idempotent)',
+      params: {
+        type: 'object',
+        properties: {
+          namespace: { $ref: 'machinist#/definitions/namespace' }
+        }
+      },
+      body: {
+        type: 'object'
+      }
+    }
+  }, async (request) => {
+    const { namespace } = request.params
+    return fastify.provider.applySecret(namespace, request.body)
+  })
+}

--- a/services/main/tests/k8s-apply-workload.test.js
+++ b/services/main/tests/k8s-apply-workload.test.js
@@ -96,6 +96,31 @@ test('applyService echoes the immutable clusterIP + resourceVersion on update', 
   assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-7')
 })
 
+test('applySecret POSTs a new Secret when none exists', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({ existing: null })
+  k8s.apiClient = client
+
+  await k8s.applySecret('platformatic', { metadata: { name: 'my-app-v1-pull' }, type: 'kubernetes.io/dockerconfigjson', data: {} })
+
+  assert.strictEqual(client.calls[0].method, 'GET')
+  assert.strictEqual(client.calls[0].path, '/api/v1/namespaces/platformatic/secrets/my-app-v1-pull')
+  assert.strictEqual(client.calls[1].method, 'POST')
+  assert.strictEqual(client.calls[1].path, '/api/v1/namespaces/platformatic/secrets')
+})
+
+test('applySecret PUTs with the existing resourceVersion on update (idempotent)', async () => {
+  const k8s = buildProvider()
+  const client = fakeClient({ existing: { metadata: { name: 'my-app-v1-pull', resourceVersion: 'rv-9' } } })
+  k8s.apiClient = client
+
+  await k8s.applySecret('platformatic', { metadata: { name: 'my-app-v1-pull' }, data: {} })
+
+  assert.strictEqual(client.calls[1].method, 'PUT')
+  assert.strictEqual(client.calls[1].path, '/api/v1/namespaces/platformatic/secrets/my-app-v1-pull')
+  assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-9')
+})
+
 test('applyDeployment rethrows non-404 probe errors', async () => {
   const k8s = buildProvider()
   const boom = new Error('boom')

--- a/services/main/tests/k8s-apply-workload.test.js
+++ b/services/main/tests/k8s-apply-workload.test.js
@@ -34,7 +34,7 @@ function fakeClient ({ existing = null } = {}) {
     calls,
     request: async (path, overrides = {}) => {
       const method = overrides.method || 'GET'
-      calls.push({ path, method, body: overrides.body ? JSON.parse(overrides.body) : undefined })
+      calls.push({ path, method, headers: overrides.headers, body: overrides.body ? JSON.parse(overrides.body) : undefined })
       if (method === 'GET') {
         if (existing) return existing
         throw notFound()
@@ -96,29 +96,18 @@ test('applyService echoes the immutable clusterIP + resourceVersion on update', 
   assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-7')
 })
 
-test('applySecret POSTs a new Secret when none exists', async () => {
+test('applySecret uses server-side apply: one PATCH, no read (never GETs secrets)', async () => {
   const k8s = buildProvider()
-  const client = fakeClient({ existing: null })
+  const client = fakeClient()
   k8s.apiClient = client
 
-  await k8s.applySecret('platformatic', { metadata: { name: 'my-app-v1-pull' }, type: 'kubernetes.io/dockerconfigjson', data: {} })
+  await k8s.applySecret('platformatic', { apiVersion: 'v1', kind: 'Secret', metadata: { name: 'my-app-v1-pull' }, type: 'kubernetes.io/dockerconfigjson', data: {} })
 
-  assert.strictEqual(client.calls[0].method, 'GET')
-  assert.strictEqual(client.calls[0].path, '/api/v1/namespaces/platformatic/secrets/my-app-v1-pull')
-  assert.strictEqual(client.calls[1].method, 'POST')
-  assert.strictEqual(client.calls[1].path, '/api/v1/namespaces/platformatic/secrets')
-})
-
-test('applySecret PUTs with the existing resourceVersion on update (idempotent)', async () => {
-  const k8s = buildProvider()
-  const client = fakeClient({ existing: { metadata: { name: 'my-app-v1-pull', resourceVersion: 'rv-9' } } })
-  k8s.apiClient = client
-
-  await k8s.applySecret('platformatic', { metadata: { name: 'my-app-v1-pull' }, data: {} })
-
-  assert.strictEqual(client.calls[1].method, 'PUT')
-  assert.strictEqual(client.calls[1].path, '/api/v1/namespaces/platformatic/secrets/my-app-v1-pull')
-  assert.strictEqual(client.calls[1].body.metadata.resourceVersion, 'rv-9')
+  assert.strictEqual(client.calls.length, 1)
+  assert.strictEqual(client.calls[0].method, 'PATCH')
+  assert.strictEqual(client.calls[0].path, '/api/v1/namespaces/platformatic/secrets/my-app-v1-pull?fieldManager=icc&force=true')
+  assert.strictEqual(client.calls[0].headers['Content-Type'], 'application/apply-patch+yaml')
+  assert.ok(!client.calls.some(c => c.method === 'GET'), 'never GETs the secret')
 })
 
 test('applyDeployment rethrows non-404 probe errors', async () => {


### PR DESCRIPTION
Adds a Secret apply endpoint so ICC can create the image-pull Secret a private-image deploy needs. The control-plane deployer API builds a dockerconfigjson Secret from the registry credentials in the deploy request and calls machinist to apply it before creating the Deployment.

- `PUT /:provider/secrets/:namespace` routes to `provider.applySecret`.
- k8s: applies the Secret with server-side apply -- a single PATCH, no read-before-write -- so the ServiceAccount needs only create and patch on secrets and never `get`.
- ecs: not applicable (ECS pulls private images via a task-definition repositoryCredentials ARN), so it throws NotImplementedByProvider.

Needs the RBAC in platformatic/helm#62 and is required by platformatic/icc-3#909.
