### PR TITLE
fix(k8s): re-read service account token on every request

### DIFF
--- a/services/main/lib/k8s-client.js
+++ b/services/main/lib/k8s-client.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const { readFile } = require('node:fs/promises')
 const { setTimeout } = require('node:timers/promises')
 const { request, Agent } = require('undici')
 const { k8sError } = require('../errors')
 
 class K8sClient {
   #dispatcher
-  #authHeaders = {}
+  #tokenPath
   #apiUrl
   #log
 
@@ -17,7 +18,7 @@ class K8sClient {
       clientCert,
       clientKey,
       caCert,
-      bearerToken,
+      tokenPath,
       apiUrl,
       log
     } = config
@@ -33,7 +34,7 @@ class K8sClient {
       tls.key = clientKey
       tls.cert = clientCert
     } else {
-      this.#authHeaders = { Authorization: `Bearer ${bearerToken}` }
+      this.#tokenPath = tokenPath
     }
 
     this.#apiUrl = apiUrl
@@ -45,15 +46,23 @@ class K8sClient {
     })
   }
 
+  // Re-read on every call rather than caching: kubelet rotates the projected
+  // token in place (default ~1h), and this process can outlive that window.
+  // The file lives on a tmpfs-backed volume, so the read is effectively free.
+  async #getAuthHeaders () {
+    if (!this.#tokenPath) return {}
+    const token = (await readFile(this.#tokenPath, 'utf8')).trim()
+    return { Authorization: `Bearer ${token}` }
+  }
+
   async request (path, overrides = {}, retryCount = 0) {
-    // TODO may need to recreate dispatcher https://kubernetes.io/docs/concepts/security/service-accounts/#authenticating-credentials
     const opts = {
       ...overrides,
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'User-Agent': 'platformatic/machinist/v3.0.0',
-        ...this.#authHeaders,
+        ...(await this.#getAuthHeaders()),
         ...(overrides.headers || {})
       },
       dispatcher: this.#dispatcher
@@ -111,7 +120,7 @@ class K8sClient {
       headers: {
         Accept: 'application/json;stream=watch',
         'User-Agent': 'platformatic/machinist/v3.0.0',
-        ...this.#authHeaders,
+        ...(await this.#getAuthHeaders()),
         ...headers
       },
       signal,

--- a/services/main/plugins/providers/k8s.js
+++ b/services/main/plugins/providers/k8s.js
@@ -19,7 +19,7 @@ const SCHEMA = {
 }
 
 class K8s {
-  constructor ({ config, log, caContent, token, authType, clientCreds }) {
+  constructor ({ config, log, caContent, tokenPath, authType, clientCreds }) {
     this.log = log
     this.config = config
     this.apiClient = new K8sClient({
@@ -28,7 +28,7 @@ class K8s {
       clientCert: clientCreds.cert,
       clientKey: clientCreds.key,
       caCert: caContent,
-      bearerToken: token,
+      tokenPath,
       apiUrl: config.PLT_K8S_REST_API_URL,
       log
     })
@@ -421,9 +421,13 @@ async function plugin (fastify, opts) {
 
   const caContent = (await readFile(appConfig.PLT_K8S_CA_PATH, 'utf8')).trim()
   const authType = appConfig.PLT_K8S_AUTH_TYPE
-  let token, clientKey, clientCert
+  let clientKey, clientCert
   if (authType === 'token') {
-    token = (await readFile(appConfig.PLT_K8S_TOKEN_PATH, 'utf8')).trim()
+    // Fail fast at startup if the token file is missing or unreadable. The
+    // value itself is re-read per request by K8sClient (see #getAuthHeaders)
+    // rather than cached here, since kubelet rotates it in place roughly
+    // every hour and this process can easily outlive that window.
+    await readFile(appConfig.PLT_K8S_TOKEN_PATH, 'utf8')
   } else {
     clientKey = Buffer.from(appConfig.PLT_K8S_CLIENT_KEY, 'base64').toString()
     clientCert = Buffer.from(appConfig.PLT_K8S_CLIENT_CERT, 'base64').toString()
@@ -431,7 +435,7 @@ async function plugin (fastify, opts) {
 
   const k8s = new K8s({
     caContent,
-    token,
+    tokenPath: appConfig.PLT_K8S_TOKEN_PATH,
     authType,
     clientCreds: { key: clientKey, cert: clientCert },
     config: appConfig,

--- a/services/main/tests/k8s-apply-workload.test.js
+++ b/services/main/tests/k8s-apply-workload.test.js
@@ -15,7 +15,7 @@ function buildProvider () {
     },
     log: { debug () {}, info () {}, warn () {}, error () {} },
     caContent: '',
-    token: 'test',
+    tokenPath: 'test',
     authType: 'token',
     clientCreds: {}
   })

--- a/services/main/tests/k8s-client.test.js
+++ b/services/main/tests/k8s-client.test.js
@@ -2,6 +2,9 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
+const { mkdtempSync, writeFileSync, rmSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
 const fastify = require('fastify')
 const K8sClient = require('../lib/k8s-client')
 
@@ -10,6 +13,16 @@ const mockLogger = {
   warn: () => {},
   info: () => {},
   debug: () => {}
+}
+
+// K8sClient re-reads the token from disk on every call (see #getAuthHeaders),
+// so tests need a real file rather than a static string.
+function writeTempToken (t, content) {
+  const dir = mkdtempSync(join(tmpdir(), 'k8s-client-test-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  const tokenPath = join(dir, 'token')
+  writeFileSync(tokenPath, content)
+  return tokenPath
 }
 
 test('K8sClient retry logic on connection reset', async t => {
@@ -38,7 +51,7 @@ test('K8sClient retry logic on connection reset', async t => {
     authType: 'token',
     allowSelfSignedCert: true,
     caCert: 'fake-ca',
-    bearerToken: 'fake-token',
+    tokenPath: writeTempToken(t, 'fake-token'),
     apiUrl,
     log: mockLogger
   })
@@ -68,7 +81,7 @@ test('K8sClient fails after max retries on connection reset', async t => {
     authType: 'token',
     allowSelfSignedCert: true,
     caCert: 'fake-ca',
-    bearerToken: 'fake-token',
+    tokenPath: writeTempToken(t, 'fake-token'),
     apiUrl,
     log: mockLogger
   })
@@ -105,7 +118,7 @@ test('K8sClient does not retry HTTP errors', async t => {
     authType: 'token',
     allowSelfSignedCert: true,
     caCert: 'fake-ca',
-    bearerToken: 'fake-token',
+    tokenPath: writeTempToken(t, 'fake-token'),
     apiUrl,
     log: mockLogger
   })
@@ -122,10 +135,47 @@ test('K8sClient has clientTtl configured', t => {
     authType: 'token',
     allowSelfSignedCert: true,
     caCert: 'fake-ca',
-    bearerToken: 'fake-token',
+    tokenPath: writeTempToken(t, 'fake-token'),
     apiUrl: 'http://localhost:8080',
     log: mockLogger
   })
 
   assert.ok(client, 'Client should be created')
+})
+
+test('K8sClient re-reads the token file on every request instead of caching it', async t => {
+  const app = fastify({ logger: false })
+
+  const seenAuthHeaders = []
+  app.get('/whoami', async (request, reply) => {
+    seenAuthHeaders.push(request.headers.authorization)
+    return { items: [] }
+  })
+
+  await app.listen({ port: 0, host: '127.0.0.1' })
+
+  t.after(async () => {
+    await app.close()
+  })
+
+  const apiUrl = `http://127.0.0.1:${app.server.address().port}`
+  const tokenPath = writeTempToken(t, 'token-v1')
+
+  const client = new K8sClient({
+    authType: 'token',
+    allowSelfSignedCert: true,
+    caCert: 'fake-ca',
+    tokenPath,
+    apiUrl,
+    log: mockLogger
+  })
+
+  await client.request('/whoami')
+
+  // Simulate kubelet rotating the token in place while the process is alive.
+  writeFileSync(tokenPath, 'token-v2')
+
+  await client.request('/whoami')
+
+  assert.deepStrictEqual(seenAuthHeaders, ['Bearer token-v1', 'Bearer token-v2'])
 })

--- a/services/main/tests/k8s-provider-coordinates.test.js
+++ b/services/main/tests/k8s-provider-coordinates.test.js
@@ -18,7 +18,7 @@ function buildProvider () {
     },
     log: { debug () {}, info () {}, warn () {}, error () {} },
     caContent: '',
-    token: 'test',
+    tokenPath: 'test',
     authType: 'token',
     clientCreds: {}
   })


### PR DESCRIPTION
K8sClient cached the bearer token once at construction time, so any pod that outlived kubelet's token rotation (~1h by default) started failing K8s API calls with 401s. Read the token fresh from disk on each request/stream call instead; the token file lives on a tmpfs-backed volume so the extra read is effectively free. Startup still does a one-time read of the token path to fail fast on misconfiguration.